### PR TITLE
Pi functionality

### DIFF
--- a/motor_control.py
+++ b/motor_control.py
@@ -10,7 +10,7 @@ import math
 import functions
 
 # Used for the verification of the baud rate by the motor controller
-rateVerify = "170"
+rateVerify = '170'
 
 # Open a serial terminal with the port 'dev/tty0'
 drive = serial.Serial(port='/dev/tty0')

--- a/motor_control.py
+++ b/motor_control.py
@@ -9,6 +9,9 @@ import serial
 import math
 import functions
 
+# Used for the verification of the baud rate by the motor controller
+rateVerify = "170"
+
 # Open a serial terminal with the port 'dev/tty0'
 drive = serial.Serial(port='/dev/tty0')
 
@@ -16,6 +19,6 @@ drive = serial.Serial(port='/dev/tty0')
 print(drive.name)
 
 # Used by the Sabertooth motor controller to autodetect the Baud Rate used by the transmitting device
-drive.write(170)
+drive.write(rateVerify)
 
 functions.trackDrive(130, 127, 'forward', 127)


### PR DESCRIPTION
Revise for pi functionality. Serial was not able to write to /dev/tty0 because of writing an int, added ' ' around 170.